### PR TITLE
make sure that changes in imported sass files trigger a rebuild

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -1,14 +1,19 @@
 var path = require('path');
 
 var appRoot = 'src/';
+var outputRoot = 'dist/';
 
 module.exports = {
   root: appRoot,
   source: appRoot + '**/*.js',
   html: appRoot + '**/*.html',
   style: 'styles/**/*.sass',
-  output: 'dist/',
+  output: outputRoot,
   doc:'./doc',
   e2eSpecsSrc: 'test/e2e/src/*.js',
-  e2eSpecsDist: 'test/e2e/dist/'
+  e2eSpecsDist: 'test/e2e/dist/',
+  styleOutput: outputRoot + 'styles.css',
+  sassIncludePaths: [
+    // add project relative sass includes paths here
+  ],
 };

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var runSequence = require('run-sequence');
 var changed = require('gulp-changed');
+var newer = require('gulp-newer');
 var plumber = require('gulp-plumber');
 var to5 = require('gulp-babel');
 var sourcemaps = require('gulp-sourcemaps');
@@ -44,16 +45,17 @@ gulp.task('build-css', function() {
     // restart the gulp watch task.
     .pipe(plumber())
 
-    // The changed step will analyze which files have changed and require
-    // rebuilding.
-    .pipe(changed(paths.output, {extension: '.css'}))
+    // The newer step will analyze if any of the input files is newer that the
+    // output so that it should be rebuilt.
+    .pipe(newer(paths.styleOutput))
 
     // The sourcemaps step will automatically generate sourcemaps.
     .pipe(sourcemaps.init())
 
     // The sass step will compile the sass. We need to specify that we are
-    // using the indented syntax.
-    .pipe(sass({indentedSyntax: true}))
+    // using the indented syntax. Also, we give a list of include paths to
+    // consider for Sass @import directives.
+    .pipe(sass({indentedSyntax: true, includePaths: paths.sassIncludePaths}))
 
     // And our last steps write the output and sourcemaps to the build
     // destination. Recall from step 3 that this is dist/.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-bump": "^0.1.11",
     "gulp-changed": "^1.1.0",
     "gulp-jshint": "^1.9.0",
+    "gulp-newer": "^1.1.0",
     "gulp-plumber": "^0.6.6",
     "gulp-protractor": "^0.0.12",
     "gulp-sourcemaps": "^1.3.0",


### PR DESCRIPTION
I came across your very helpful blog post at http://www.foursails.co/blog/building-sass/, but I realized that the change detection with `@import` directives didn't work. Here's a proposed fix using gulp-newer. You might also consider to include it in the mentioned post. Thanks!